### PR TITLE
fix: chrome-only role color update bug

### DIFF
--- a/src/routes/(app)/org/[id=integer]/settings/roles/+page.server.ts
+++ b/src/routes/(app)/org/[id=integer]/settings/roles/+page.server.ts
@@ -127,7 +127,7 @@ export const actions = {
 					id: role.id
 				},
 				data: {
-					name: name,
+					name,
 					color,
 					permissionInt
 				}

--- a/src/routes/(app)/org/[id=integer]/settings/roles/Role.svelte
+++ b/src/routes/(app)/org/[id=integer]/settings/roles/Role.svelte
@@ -13,6 +13,7 @@
 	} from '$lib/permissions/orgPermissions';
 	import { createPermissionsNumber } from '$lib/permissions/permissions';
 	import { toTitleCase } from '$lib/titleCase';
+	import { tick } from 'svelte';
 
 	export let role: {
 		id: number;
@@ -23,10 +24,13 @@
 
 	let colorInput: HTMLInputElement;
 	let submitButton: HTMLButtonElement;
-	let permissionIntInput: HTMLInputElement;
+	let permissionIntInput: string;
 
 	const valueChanged = () => {
-		submitButton.click();
+		tick().then(() => {
+			console.log(permissionObject, permissionIntInput);
+			submitButton.click()
+		});
 	};
 
 	const openColorInput = () => {
@@ -42,10 +46,9 @@
 	const permissionObject = createOrgPermissionsCheck(role.permissionInt);
 
 	$: if (permissionObject) {
+		permissionIntInput = createPermissionsNumber(permissionObject).toString();
 		if (createPermissionsNumber(permissionObject) != permissionIntCalculated) {
-			permissionIntCalculated = createPermissionsNumber(permissionObject);
-			permissionIntInput.value = permissionIntCalculated.toString();
-			submitButton.click();
+			tick().then(() => submitButton.click());
 		}
 	}
 
@@ -136,7 +139,7 @@
 		{/each}
 	</div>
 
-	<input bind:this={permissionIntInput} name="permissionInt" hidden />
+	<input bind:value={permissionIntInput} name="permissionInt" hidden />
 
 	<button bind:this={submitButton} hidden type="submit" />
 </form>


### PR DESCRIPTION
fixes bug in chrome that causes permission ints to reset when changing color; caused by small chrome input quirk happening before svelte's dom tick